### PR TITLE
Adds Fired tracking to all defaults and readme

### DIFF
--- a/Collections/Ammunition Tracking/ammo.snippet
+++ b/Collections/Ammunition Tracking/ammo.snippet
@@ -1,9 +1,10 @@
 {{c = 'Ammo'}}
-{{C, ammoF = 'Used ' + c, get('ammoF', 0) + 1}}
+{{C, F, ammoF = 'Used ' + c, 'Fired ' + c, get('ammoF', 0) + 1}}
 {{create_cc_nx(C, 0)}}
+{{create_cc_nx(F, 0)}}
 {{(create_cc_nx(c, 0), set_cc(c, 20)) if not cc_exists(c) else ''}}
 {{v = get_cc(c) > 0}}
 {{miss = get('miss', 0) + (not v)}}
-{{(mod_cc(c, -1), mod_cc(C, 1)) if v else f'miss{miss}'}}
+{{(mod_cc(c, -1), mod_cc(C, 1), mod_cc(F,1)) if v else f'miss{miss}'}}
 {{f'-phrase "{"Using a piece of ammunition" if ammoF == 1 else "...and another one"} ({get_cc(c)} remaining)"'}}
 {{'' if ammoF > 1 else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}

--- a/Collections/Ammunition Tracking/ammo.snippet
+++ b/Collections/Ammunition Tracking/ammo.snippet
@@ -1,10 +1,11 @@
 {{c = 'Ammo'}}
-{{C, F, ammoF = 'Used ' + c, 'Fired ' + c, get('ammoF', 0) + 1}}
+{{C, F, ammoF, track = 'Used ' + c, 'Fired ' + c, get('ammoF', 0) + 1, get_svar('trackShots') or get('trackShots')}}
 {{create_cc_nx(C, 0)}}
-{{create_cc_nx(F, 0)}}
+{{create_cc_nx(F, 0) if track else ''}}
 {{(create_cc_nx(c, 0), set_cc(c, 20)) if not cc_exists(c) else ''}}
 {{v = get_cc(c) > 0}}
 {{miss = get('miss', 0) + (not v)}}
-{{(mod_cc(c, -1), mod_cc(C, 1), mod_cc(F,1)) if v else f'miss{miss}'}}
+{{(mod_cc(c, -1), mod_cc(C, 1)) if v else f'miss{miss}'}}
+{{mod_cc(F, 1) if v and track else ''}}
 {{f'-phrase "{"Using a piece of ammunition" if ammoF == 1 else "...and another one"} ({get_cc(c)} remaining)"'}}
 {{'' if ammoF > 1 else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}

--- a/Collections/Ammunition Tracking/arrow.snippet
+++ b/Collections/Ammunition Tracking/arrow.snippet
@@ -1,9 +1,10 @@
 {{c = 'Arrows'}}
-{{C, arrowF = 'Used ' + c, get('arrowF', 0) + 1}}
+{{C, F, arrowF = 'Used ' + c, 'Fired ' + c, get('arrowF', 0) + 1}}
 {{create_cc_nx(C, 0)}}
+{{create_cc_nx(F, 0)}}
 {{(create_cc_nx(c, 0), set_cc(c, 20)) if not cc_exists(c) else ''}}
 {{v = get_cc(c) > 0}}
 {{miss = get('miss', 0) + (not v)}}
-{{(mod_cc(c, -1), mod_cc(C, 1)) if v else f'miss{miss}'}}
+{{(mod_cc(c, -1), mod_cc(C, 1), mod_cc(F,1)) if v else f'miss{miss}'}}
 {{f'-phrase "{"Using an arrow" if arrowF == 1 else "...and another one"} ({get_cc(c)} remaining)"'}}
 {{'' if arrowF > 1 else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}

--- a/Collections/Ammunition Tracking/arrow.snippet
+++ b/Collections/Ammunition Tracking/arrow.snippet
@@ -1,10 +1,11 @@
 {{c = 'Arrows'}}
-{{C, F, arrowF = 'Used ' + c, 'Fired ' + c, get('arrowF', 0) + 1}}
+{{C, F, arrowF, track = 'Used ' + c, 'Fired ' + c, get('arrowF', 0) + 1, get_svar('trackShots') or get('trackShots')}}
 {{create_cc_nx(C, 0)}}
-{{create_cc_nx(F, 0)}}
+{{create_cc_nx(F, 0) if track else ''}}
 {{(create_cc_nx(c, 0), set_cc(c, 20)) if not cc_exists(c) else ''}}
 {{v = get_cc(c) > 0}}
 {{miss = get('miss', 0) + (not v)}}
-{{(mod_cc(c, -1), mod_cc(C, 1), mod_cc(F,1)) if v else f'miss{miss}'}}
+{{(mod_cc(c, -1), mod_cc(C, 1)) if v else f'miss{miss}'}}
+{{mod_cc(F, 1) if v and track else ''}}
 {{f'-phrase "{"Using an arrow" if arrowF == 1 else "...and another one"} ({get_cc(c)} remaining)"'}}
 {{'' if arrowF > 1 else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}

--- a/Collections/Ammunition Tracking/bolt.snippet
+++ b/Collections/Ammunition Tracking/bolt.snippet
@@ -1,10 +1,11 @@
 {{c = 'Bolts'}}
-{{C, F, boltF = 'Used ' + c, 'Fired ' + c, get('boltF', 0) + 1}}
+{{C, F, boltF, track = 'Used ' + c, 'Fired ' + c, get('boltF', 0) + 1, get_svar('trackShots') or get('trackShots')}}
 {{create_cc_nx(C, 0)}}
-{{create_cc_nx(F, 0)}}
+{{create_cc_nx(F, 0) if track else ''}}
 {{(create_cc_nx(c, 0), set_cc(c, 20)) if not cc_exists(c) else ''}}
 {{v = get_cc(c) > 0}}
 {{miss = get('miss', 0) + (not v)}}
-{{(mod_cc(c, -1), mod_cc(C, 1), mod_cc(F,1)) if v else f'miss{miss}'}}
+{{(mod_cc(c, -1), mod_cc(C, 1)) if v else f'miss{miss}'}}
+{{mod_cc(F, 1) if v and track else ''}}
 {{f'-phrase "{"Using a bolt" if boltF == 1 else "...and another one"} ({get_cc(c)} remaining)"'}}
 {{'' if boltF > 1 else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}

--- a/Collections/Ammunition Tracking/bolt.snippet
+++ b/Collections/Ammunition Tracking/bolt.snippet
@@ -1,9 +1,10 @@
 {{c = 'Bolts'}}
-{{C, boltF = 'Used ' + c, get('boltF', 0) + 1}}
+{{C, F, boltF = 'Used ' + c, 'Fired ' + c, get('boltF', 0) + 1}}
 {{create_cc_nx(C, 0)}}
+{{create_cc_nx(F, 0)}}
 {{(create_cc_nx(c, 0), set_cc(c, 20)) if not cc_exists(c) else ''}}
 {{v = get_cc(c) > 0}}
 {{miss = get('miss', 0) + (not v)}}
-{{(mod_cc(c, -1), mod_cc(C, 1)) if v else f'miss{miss}'}}
+{{(mod_cc(c, -1), mod_cc(C, 1), mod_cc(F,1)) if v else f'miss{miss}'}}
 {{f'-phrase "{"Using a bolt" if boltF == 1 else "...and another one"} ({get_cc(c)} remaining)"'}}
 {{'' if boltF > 1 else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}

--- a/Collections/Ammunition Tracking/bullet.snippet
+++ b/Collections/Ammunition Tracking/bullet.snippet
@@ -1,9 +1,10 @@
 {{c='Bullets'}}
-{{v=cc_exists(c)}}
+{{v, F=cc_exists(c), 'Fired ' + c}}
 {{create_cc_nx(c, 0)}}
+{{create_cc_nx(F, 0)}}
 {{"" if v else set_cc(c, 20)}}
 {{v=1 if get_cc(c) > 0 else 0}}
-{{mod_cc(c, -1) if v else ""}}
+{{(mod_cc(c, -1),mod_cc(F,1)) if v else ""}}
 {{"" if v else "miss"}}
 {{"" if v else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}
 {{bulletF=get('bulletF',0)+1}}

--- a/Collections/Ammunition Tracking/bullet.snippet
+++ b/Collections/Ammunition Tracking/bullet.snippet
@@ -1,10 +1,11 @@
 {{c='Bullets'}}
-{{v, F=cc_exists(c), 'Fired ' + c}}
+{{v, F, track = cc_exists(c), 'Fired ' + c, get_svar('trackShots') or get('trackShots')}}
 {{create_cc_nx(c, 0)}}
-{{create_cc_nx(F, 0)}}
+{{create_cc_nx(F, 0) if track else ''}}
 {{"" if v else set_cc(c, 20)}}
 {{v=1 if get_cc(c) > 0 else 0}}
-{{(mod_cc(c, -1),mod_cc(F,1)) if v else ""}}
+{{(mod_cc(c, -1)) if v else ""}}
+{{mod_cc(F, 1) if v and track else ''}}
 {{"" if v else "miss"}}
 {{"" if v else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}
 {{bulletF=get('bulletF',0)+1}}

--- a/Collections/Ammunition Tracking/readme.md
+++ b/Collections/Ammunition Tracking/readme.md
@@ -1,15 +1,16 @@
-This collection provides a variety of snippets to expend ammunition, as well as the `!collect` alias to retrieve your ammunition after a fight.
+This collection provides a variety of snippets to expend ammunition and track its use, as well as the `!collect` alias to retrieve your ammunition after a fight.
 
 If you would like to create additional snippets for other types of ammunition, you can create a snippet like such:
 
 ```py
-!snippet arrow {{c = 'AMMONAMEHERE'}}
-{{C, ammoNameHereF = 'Used ' + c, get('ammoNameHereF', 0) + 1}}
+!snippet ammoNameHere {{c = 'AMMONAMEHERE'}}
+{{C, F, ammoNameHereF = 'Used ' + c, 'Fired ' + c, get('ammoNameHereF', 0) + 1}}
 {{create_cc_nx(C, 0)}}
+{{create_cc_nx(F, 0)}}
 {{(create_cc_nx(c, 0), set_cc(c, 20)) if not cc_exists(c) else ''}}
 {{v = get_cc(c) > 0}}
 {{miss = get('miss', 0) + (not v)}}
-{{(mod_cc(c, -1), mod_cc(C, 1)) if v else f'miss{miss}'}}
+{{(mod_cc(c, -1), mod_cc(C, 1), mod_cc(F,1)) if v else f'miss{miss}'}}
 {{f'-phrase "{"Using a piece of AMMONAMEHERE" if ammoNameHereF == 1 else "...and another one"} ({get_cc(c)} remaining)"'}}
 {{'' if ammoNameHereF > 1 else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}
 ```

--- a/Collections/Ammunition Tracking/readme.md
+++ b/Collections/Ammunition Tracking/readme.md
@@ -1,16 +1,18 @@
-This collection provides a variety of snippets to expend ammunition and track its use, as well as the `!collect` alias to retrieve your ammunition after a fight.
+This collection provides a variety of snippets to expend ammunition, as well as the `!collect` alias to retrieve your ammunition after a fight.
+If you want to track the ammo fired create an svar|cvar|uvar named `trackShots` (EX: `!cvar trackShots 1`)
 
 If you would like to create additional snippets for other types of ammunition, you can create a snippet like such:
 
 ```py
 !snippet ammoNameHere {{c = 'AMMONAMEHERE'}}
-{{C, F, ammoNameHereF = 'Used ' + c, 'Fired ' + c, get('ammoNameHereF', 0) + 1}}
+{{C, F, ammoNameHereF, track = 'Used ' + c, 'Fired ' + c, get('ammoNameHereF', 0) + 1, get_svar('trackShots') or get('trackShots')}}
 {{create_cc_nx(C, 0)}}
-{{create_cc_nx(F, 0)}}
+{{create_cc_nx(F, 0) if track else ''}}
 {{(create_cc_nx(c, 0), set_cc(c, 20)) if not cc_exists(c) else ''}}
 {{v = get_cc(c) > 0}}
 {{miss = get('miss', 0) + (not v)}}
-{{(mod_cc(c, -1), mod_cc(C, 1), mod_cc(F,1)) if v else f'miss{miss}'}}
+{{(mod_cc(c, -1), mod_cc(C, 1)) if v else f'miss{miss}'}}
+{{mod_cc(F, 1) if v and track else ''}}
 {{f'-phrase "{"Using a piece of AMMONAMEHERE" if ammoNameHereF == 1 else "...and another one"} ({get_cc(c)} remaining)"'}}
 {{'' if ammoNameHereF > 1 else '-f "Ammunition|You can use a weapon that has the ammunition property to make a ranged attack only if you have ammunition to fire from the weapon. (PHB 146)"'}}
 ```


### PR DESCRIPTION
### What Alias/Snippet is this for?
Ammo Tracking Collection

### Summary
Adds Fired tracking to all defaults and readme. Used for keeping tracking of all fired ammo, not altered by collect. Added optional svar|cvar|uvar trackshots to only track if found.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [] I properly commented my code where appropriate
