### PR TITLE
Allow caps in -savemap names #36 Issue Fix

### DIFF
--- a/Collections/Map Utilities/map.alias
+++ b/Collections/Map Utilities/map.alias
@@ -367,7 +367,7 @@ if args.last('mapload') or args.last('loadmap'):
 if args.last('newmapbg') or args.last('deletemapbg') or args.last('savemap') or args.last('deletemap'):
  #First option is to create mapbg preset
  if args.last('newmapbg') or args.last('savemap'):
-  mapName = (args.last('savemap') or args.last('newmapbg')).lower()
+  mapName = (args.last('savemap') or args.last('newmapbg'))
   mapBGState = {}
   formedMap = {mapName:mapBGState}
   for key, value in mapinfo.items():


### PR DESCRIPTION
### What Alias/Snippet is this for?
!map

### Summary
Just removed .lower() when saving maps so map names can have capital letters but loading them still is case-insensitive.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
