### PR TITLE
Fixed -mapsize bug

### DIFF
--- a/Collections/Map Utilities/map.alias
+++ b/Collections/Map Utilities/map.alias
@@ -204,7 +204,10 @@ if c:
   # Split and convert to dict. Couldn't use | here because of how -attack effects are parsed
   mapinfo=mapinfo.split(' ~ ')
   mapinfo={x[0].lower():x[1] for x in [item.split(': ') for item in mapinfo]}
-  mapsize=mapinfo.get('size')
+  if mapinfo.get('size') == None:
+    mapsize = defaults.get("size", "10x10") or "10x10"
+  else:
+    mapsize=mapinfo.get('size')
   #If user hasn't set mapsize = "JSON" then continue
   if mapsize != "JSON":
    if ":" in mapsize:


### PR DESCRIPTION
### What Alias/Snippet is this for?
!map

### Summary
When applying the attack effect "Map" to combatant via !init -note (like you would when using !bplan or !battle), if the user didn't set the mapsize it would error. Fixed it will do default 10x10 or svar mapDefaults if no variable is given.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
