### PR TITLE
Fix offset info, improve grid size info

### DIFF
--- a/Collections/Map Utilities/map.alias
+++ b/Collections/Map Utilities/map.alias
@@ -1712,7 +1712,7 @@ elif (not c or args.get('?') or args.get('help')) and not args.get("tokenimport"
              `n` - Hides the grid.
              `e` - Everything outside the map's edges becomes invisible.
              `f` - Use alternative grid/token font
-             `c<#>` - Sets the grid's unit size (in px). Default: 60 Minimum: 20 Maximum: 100
+             `c<#>` - Sets the grid's unit size (in px). Default: 40 Minimum: 20 Maximum: 100
              `o<#>:<#>` - Offsets the background image by x:y (in px). Example: `!map -options o20:40` would offset it 20px to the right and 40px down.
              "
              -f "_ _|Run `-options` without a specific argument to revert its change. With no arguments it'll reset every change.

--- a/Collections/Map Utilities/map.alias
+++ b/Collections/Map Utilities/map.alias
@@ -1712,8 +1712,8 @@ elif (not c or args.get('?') or args.get('help')) and not args.get("tokenimport"
              `n` - Hides the grid.
              `e` - Everything outside the map's edges becomes invisible.
              `f` - Use alternative grid/token font
-             `c<#>` - Sets the grid's unit size (in px). Default: 60.
-             `o<#>:<#>` - Offsets the background image (in px). Example: `!map -options o20:40` would offset it 20px down and 40px to the right.
+             `c<#>` - Sets the grid's unit size (in px). Default: 60 Minimum: 20 Maximum: 100
+             `o<#>:<#>` - Offsets the background image by x:y (in px). Example: `!map -options o20:40` would offset it 20px to the right and 40px down.
              "
              -f "_ _|Run `-options` without a specific argument to revert its change. With no arguments it'll reset every change.
              You can set multiple settings at a time. Example: `!map -options dc70o10:20z2e`

--- a/Collections/Map Utilities/move.alias
+++ b/Collections/Map Utilities/move.alias
@@ -1712,7 +1712,7 @@ elif (not c or args.get('?') or args.get('help')) and not args.get("tokenimport"
              `n` - Hides the grid.
              `e` - Everything outside the map's edges becomes invisible.
              `f` - Use alternative grid/token font
-             `c<#>` - Sets the grid's unit size (in px). Default: 60 Minimum: 20 Maximum: 100
+             `c<#>` - Sets the grid's unit size (in px). Default: 40 Minimum: 20 Maximum: 100
              `o<#>:<#>` - Offsets the background image by x:y (in px). Example: `!map -options o20:40` would offset it 20px to the right and 40px down.
              "
              -f "_ _|Run `-options` without a specific argument to revert its change. With no arguments it'll reset every change.

--- a/Collections/Map Utilities/move.alias
+++ b/Collections/Map Utilities/move.alias
@@ -1712,8 +1712,8 @@ elif (not c or args.get('?') or args.get('help')) and not args.get("tokenimport"
              `n` - Hides the grid.
              `e` - Everything outside the map's edges becomes invisible.
              `f` - Use alternative grid/token font
-             `c<#>` - Sets the grid's unit size (in px). Default: 60.
-             `o<#>:<#>` - Offsets the background image (in px). Example: `!map -options o20:40` would offset it 20px down and 40px to the right.
+             `c<#>` - Sets the grid's unit size (in px). Default: 60 Minimum: 20 Maximum: 100
+             `o<#>:<#>` - Offsets the background image by x:y (in px). Example: `!map -options o20:40` would offset it 20px to the right and 40px down.
              "
              -f "_ _|Run `-options` without a specific argument to revert its change. With no arguments it'll reset every change.
              You can set multiple settings at a time. Example: `!map -options dc70o10:20z2e`

--- a/Collections/Testing Aliases/mapTest.alias
+++ b/Collections/Testing Aliases/mapTest.alias
@@ -1617,8 +1617,8 @@ elif not c or args.get('?') or args.get('help'):
              `n` - Hides the grid.
              `e` - Everything outside the map's edges becomes invisible.
              `f` - Use alternative grid/token font
-             `c<#>` - Sets the grid's unit size (in px). Default: 60.
-             `o<#>:<#>` - Offsets the background image (in px). Example: `!map -options o20:40` would offset it 20px down and 40px to the right.
+             `c<#>` - Sets the grid's unit size (in px). Default: 60 Minimum: 20 Maximum: 100
+             `o<#>:<#>` - Offsets the background image by x:y (in px). Example: `!map -options o20:40` would offset it 20px to the right and 40px down.
              Run `-options` without a specific argument to revert its change. With no arguments it'll reset every change.
              You can set multiple settings at a time. Example: `!map -options dc70o10:20z2e`"
              -f "_ _|**__Backup / Restore__**

--- a/Collections/Testing Aliases/mapTest.alias
+++ b/Collections/Testing Aliases/mapTest.alias
@@ -1617,7 +1617,7 @@ elif not c or args.get('?') or args.get('help'):
              `n` - Hides the grid.
              `e` - Everything outside the map's edges becomes invisible.
              `f` - Use alternative grid/token font
-             `c<#>` - Sets the grid's unit size (in px). Default: 60 Minimum: 20 Maximum: 100
+             `c<#>` - Sets the grid's unit size (in px). Default: 40 Minimum: 20 Maximum: 100
              `o<#>:<#>` - Offsets the background image by x:y (in px). Example: `!map -options o20:40` would offset it 20px to the right and 40px down.
              Run `-options` without a specific argument to revert its change. With no arguments it'll reset every change.
              You can set multiple settings at a time. Example: `!map -options dc70o10:20z2e`"


### PR DESCRIPTION
### What Alias/Snippet is this for?
map and move
### Summary
The information in the help about offset was backwards.
The information on grid pixel size did not include minimum and maximum values.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
