### PR TITLE
Make !grapple default to current combatant if char not in init

### DIFF
--- a/Collections/Grapple/grapple.alias
+++ b/Collections/Grapple/grapple.alias
@@ -3,7 +3,7 @@ embed
 # Baseline Variables
 args     = argparse(&ARGS&)
 c        = combat()
-grappler = args.last("c", name)
+grappler = args.last("c", name if not c or not c.current or c.me else c.current.name)
 target   = args.last("t")
 
 grapplerStatOverride = args.last("stat")


### PR DESCRIPTION
### What Alias/Snippet is this for?
!grapple

### Summary
Just a one-line change to make !grapple default to current combatant if the active character isn't in init. Makes it more convenient for DMs to use it for monsters.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
