### PR TITLE
Add a `-stats #` to adjust the number of stats rolled in `!threshold`

### DIFF
--- a/Collections/Random Stat Generation - Threshold/threshold.alias
+++ b/Collections/Random Stat Generation - Threshold/threshold.alias
@@ -11,6 +11,7 @@ Max      = args.last("max", type_ = int)
 dice     = args.last("dice", "4d6kh3", str)
 rr       = args.last("rr", 1, int)
 tries    = args.last("tries", 10, int)
+amt      = args.last("stats", 6, int)
 under    = [x.split('|') for x in args.get("under", [], str)]
 over     = [x.split('|') for x in args.get("over", [], str)]
 straight = 'straight' in args
@@ -24,6 +25,7 @@ Allows for rolling character stats while imposing a set of rules on the outcome.
 `-dice <dice>` - The dice to be rolled for each stat. Default: `4d6kh3`
 `-rr <#>` - The number of sets to be displayed. Default: 1
 `-tries <#>` - The number of attempts it will try to find sets matching the rules.
+`-stats <#>` - The number of stats to roll.  Default: 6
 `straight` - Will assign stats to each score.
 
 `-min <#>` - The minimum total of the combined rolls.
@@ -39,9 +41,9 @@ In the footer of the alias when it rolls stats, it will show a signature. You ca
 """
 </drac2>
 
-{{a=[y for x in range(tries) if set('y',[vroll(dice) for i in range(6)]) or (all([sum([1 for i in y if i.total<int(x[0])])>=int(x[1]) for x in under]) and all([sum([1 for i in y if i.total>int(x[0])])>=int(x[1]) for x in over]) and (sum([i.total for i in y])<=Max if Max else 1) and (sum([i.total for i in y])>=Min if Min else 1)) ] if not help else ""}}
+{{a=[y for x in range(tries) if set('y',[vroll(dice) for i in range(amt)]) or (all([sum([1 for i in y if i.total<int(x[0])])>=int(x[1]) for x in under]) and all([sum([1 for i in y if i.total>int(x[0])])>=int(x[1]) for x in over]) and (sum([i.total for i in y])<=Max if Max else 1) and (sum([i.total for i in y])>=Min if Min else 1)) ] if not help else ""}}
 
-{{help or (' '.join([f'-f "Stats {f"#{x+1}" if len(a[:rr])>1 else ""}|' + '\n'.join([(f"**{stats[i]}:** "*straight)+str(a[x][i]) for i in range(len(a[x]))])+f"\n-----\nTotal =  `{sum([i.total for i in a[x]])}`"+'"' for x in range(len(a[:rr]))]) if len(a)>=rr else err('Not enough sets following the given rules. Try again, or increase the number of attempts using `-tries #`.'))}}
+{{help or (' '.join([f'-f "Stats {f"#{x+1}" if len(a[:rr])>1 else ""}|' + '\n'.join([(f"**{stats[i] if not args.last('stats') else f'Stat {i+1}'}:** "*straight)+str(a[x][i]) for i in range(len(a[x]))])+f"\n-----\nTotal =  `{sum([i.total for i in a[x]])}`"+'"' for x in range(len(a[:rr]))]) if len(a)>=rr else err('Not enough sets following the given rules. Try again, or increase the number of attempts using `-tries #`.'))}}
 
 
 -title "{{"Ugh, randchar spam" if help else "Generating random stats:"}}"


### PR DESCRIPTION

### What Alias/Snippet is this for?
`!threshold`
### Summary
Added additional option for rolling a custom number of stats.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
