### PR TITLE
Clarified targeted concentration checks and added Transmuter's Stone …

### DIFF
--- a/Collections/Initiative Utilities/conc.alias
+++ b/Collections/Initiative Utilities/conc.alias
@@ -2,26 +2,32 @@ embed
 
 <drac2>
 c = combat()
-warcaster = 'warcaster' in get('feats', '').lower().replace(' ', '')
-mind = 'eldritch mind' in get('invocations', '').lower()
-args = argparse(&ARGS& + (["adv"] if warcaster or mind else []))
-effect = None
-
 target = args.last('t', name)
 self = target == name
+args = argparse(&ARGS&)
+
+warcaster = 'warcaster' in get('feats', '').lower().replace(' ', '') and self
+mind = 'eldritch mind' in get('invocations', '').lower() and self
+if warcaster or mind:
+    args['adv'] = True
+effect = None
+
 dc = args.last('dc', 10, int)
 b = args.join("b", ' + ')
 adv = args.adv(boolwise=True)
-bladesong = args.last('bs') if target == name else None
+bladesong = args.last('bs') if self else None
+transmuter = args.last('ts') if self else None
 
 if c and (target := c.get_combatant(target)):
  effect     = ([eff for eff in target.effects if eff.conc] + [None])[0]
  bladesong  = bladesong or target.get_effect("Bladesong")
+ transmuter = transmuter or target.get_effect("Transmuter's Stone")
  sb         = ' + '.join([eff.effect.sb for eff in target.effects if 'sb' in eff.effect])
  rollString = f"{target.saves.get('constitution').d20(adv)}" +  \
              (f' + {b}' if b else '') +  \
              (f' + {sb}' if sb else '') + \
-             (f' + {max(1, (target.stats.get_mod("int")))} [bladesong]' if bladesong else '')
+             (f' + {max(1, (target.stats.get_mod("int")))} [bladesong]' if bladesong else '') + \
+             (f' + {(target.stats.prof_bonus)} [transmuter stone]' if transmuter else '')
  concRoll   = vroll(rollString)
  success    = concRoll.total >= dc
  concOut    = f"""-title "{target.name} makes a Concentration Save!"
@@ -30,7 +36,7 @@ if c and (target := c.get_combatant(target)):
  if not success:
   if effect:
    concOut   = concOut[:-2] + f"""\nYou are no longer concentrating on {effect.name} and the effects have been removed." """
-   if "Mind Sharpener" in get("infusions",""):
+   if "Mind Sharpener" in get("infusions","") and self:
     character().set_cvar("lastEffect", dump_json([target.get_effect(effect.name).name, target.get_effect(effect.name).remaining]))
     concOut   = concOut + f"""-f "Mind Sharpener|Effect stored for Mind Sharpener Infusion." """
    target.remove_effect(effect.name)


### PR DESCRIPTION


### What Alias/Snippet is this for?
`!conc` from the Initiative Utilities collection

### Summary
Added "self" requirement to features retrieved from active character (such as Eldritch Mind, Warcaster, Mind Sharpener, and Bladesinging) to avoid extraneous/erroneous information when targeting a non-active Concentration Check. 
Transmuter Stone functionality added, accessed through "ts" argument or "Transmuter's Stone" effect, similar to current Bladesinger implementation.
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
- [X] I properly commented my code where appropriate
