### PR TITLE
Make reckless.snippet respect custom verbs

### DIFF
--- a/Collections/Barbarian Basics/reckless.snippet
+++ b/Collections/Barbarian Basics/reckless.snippet
@@ -1,5 +1,5 @@
 adv
--title "[name] attacks recklessly with [aname]!"
+-title "[name] recklessly [verb] [aname]!"
 -f "Reckless Attack|Melee attacks this turn have advantage. All attacks made against you until the start of your next turn have advantage."
 
 <drac2>


### PR DESCRIPTION
### What Alias/Snippet is this for?

reckless.snippet

### Summary
Currently it changes the title but disregards any custom verb the user has for the attack.

This PR changes it so that the custom verb is used.

There's a slight change in word order to make this work ("Example recklessly attacks with a Weapon!" rather than "Example attacks recklessly with a Weapon") but I don't think this is a problem.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
