### PR TITLE
scast bug: Don't expend sorcery points when not enough spell slots

### DIFF
--- a/Collections/Sorcerer Basics/scast.alias
+++ b/Collections/Sorcerer Basics/scast.alias
@@ -36,7 +36,7 @@ if not character().cc_exists(cc) and meta_cost:
 elif meta_cost:
   if character().cc_exists(cc) and character().get_cc(cc) >= meta_cost:
     # If the character cannot cast the spell at the level specified, safely error before expending sorcery points
-    if character().spellbook.get_slots(spell_level) == 0:
+    if character().spellbook.get_slots(spell_level) == 0 and not argparse(args).last('i'):
       return f"""embed -title "Cannot cast spell!" -desc "You don't have enough level {spell_level} slots left! Use `-l <level>` to cast at a different level, `!g lr` to take a long rest, or `-i` to ignore spell slots!" """
 
     character().mod_cc(cc, -meta_cost)

--- a/Collections/Sorcerer Basics/scast.alias
+++ b/Collections/Sorcerer Basics/scast.alias
@@ -35,6 +35,10 @@ if not character().cc_exists(cc) and meta_cost:
   return f"""embed -title "I'm sorry {ctx.author.display_name}, I can't let you do that." -desc "You are missing a Sorcery Points custom counter. You can either create one yourself (`!help cc create`), or use the [`{ctx.prefix}level` alias](https://avrae.io/dashboard/workshop/5f7385fe647bb0a416316d1d)." """
 elif meta_cost:
   if character().cc_exists(cc) and character().get_cc(cc) >= meta_cost:
+    # If the character cannot cast the spell at the level specified, safely error before expending sorcery points
+    if character().spellbook.get_slots(spell_level) == 0:
+      return f"""embed -title "Cannot cast spell!" -desc "You don't have enough level {spell_level} slots left! Use `-l <level>` to cast at a different level, `!g lr` to take a long rest, or `-i` to ignore spell slots!" """
+
     character().mod_cc(cc, -meta_cost)
   else:
     return f"""embed -title "I'm sorry {ctx.author.display_name}, I can't let you do that." -desc "You don't have enough Sorcery Points for that." """


### PR DESCRIPTION
### What Alias/Snippet is this for?
`!scast`

### Summary
When a sorcerer uses `!scast` with metamagic but does not have enough spell slots at the given level for the spell, current behavior is that Sorcery Points are quietly expended even when the casting fails. This change ensures that before Sorcery Points are expended, we check that the caster has spell slots at that level and safely fail if they do not. Existing behavior is maintained in the cases when non-spellcasters or non-sorcerer casters attempt to use `!scast`.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [x] I properly commented my code where appropriate
