### PR TITLE
Make `!map ?` work again to match the footer

### DIFF
--- a/Collections/Map Utilities/map.alias
+++ b/Collections/Map Utilities/map.alias
@@ -1660,7 +1660,7 @@ elif args.get('objectlist'):
  # Add some pizazz
  return objectlist + f"""-title "I've got a loveley bunch of Objects, diddly dee" """
 # If we're not in combat, or "?" or "help" are given as arguments, display the help
-elif (not c or args.get('?') or args.get('help')) and not args.get("tokenimport"):
+elif (not c or '?' in argList or args.get('help')) and not args.get("tokenimport"):
  if any(args.last(potentialArg) for potentialArg in ('overlay', 'over', 'overlays', 'spell', 'spells')):
   help = f"""-title "Maps: overlays and spells"
             -desc "{["Bro","Broski","Brotein","Brosicle","Broseph","Brotastic","Han Brolo","Broba Fett","Brotato Chip","Broseidon","Brochacho","Broebh"][randint(12)]}, I'm so Over this!


### PR DESCRIPTION

### What Alias/Snippet is this for?
`!map`
### Summary
Here goes a short summary about what the PR is about.
`!map ?` stopped working for some reason, possibly the update to argparse() ?  This change fixes it.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
