### PR TITLE
Previous or forced group naming and error options

### DIFF
--- a/Collections/Croebhs Summon Alias/summon aberration.alias
+++ b/Collections/Croebhs Summon Alias/summon aberration.alias
@@ -54,7 +54,7 @@ match summon_type:
     attacks = [{"name":"Psychic Slam","automation":[{"type":"target","target":"each","effects":[{"type":"attack","attackBonus":sab,"hit":[{"type":"damage","damage":f"1d8 + 3 + {spell_level} [psychic]"}],"miss":[]}]},{"type":"text","text":"*Melee Spell Attack:* your spell attack modifier to hit, reach 5 ft., one creature. *Hit:* 1d8 + 3 + the spell's level psychic damage."}],"_v":2,"verb":None,"proper":False,"activation_type":None},{"name":"Whispering Aura","automation":[{"type":"roll","dice":"2d6 [psychic]","name":"damage"},{"type":"target","target":"each","effects":[{"type":"save","stat":"wis","dc":sdc,"fail":[{"type":"damage","damage":"{damage}"}],"success":[]}],"meta":[]},{"type":"text","text":"At the start of each of the aberration's turns, each creature within 5 feet of the aberration must succeed on a Wisdom saving throw against your spell save DC or take 2d6 psychic damage, provided that the aberration isn't incapacitated."}],"_v":2,"verb":"exudes"}]
     summon_name = "Star Spawn"
   case _:
-    return f"""embed -title "Woopsie!" -desc "You didn't select a type!" """
+    return f"""embed -title "Woopsie!" -desc "You didn't select a type!\n\nChoose from Beholder, Slaad or Star Spawn." """
 
 if not ignore:
   if not ch.spellbook.get_slots(spell_level):
@@ -73,10 +73,10 @@ ch.set_cvar('summon_names', dump_yaml(custom_names))
 s_name = custom_names.get(summon_name, f"Summoned {summon_name} {TYPE} ({init_add.get_initials(name)})")
 
 stat_block['p'] = True
-stat_block['group'] = f"{init_add.get_initials(name)}'s Summons"
+stat_block['group'] = combat().me.group or args.last('group', f"{init_add.get_initials(name)}'s Summons")
 stat_block['note'] = f"Summoned by {name}\nMultiattack: {max(1, spell_level//2)}"
 
-c.me.set_group(f"{init_add.get_initials(name)}'s Summons")
+c.me.set_group(stat_block['group'])
 c.me.add_effect(f"Summon {TYPE}", concentration=True, duration=600)
 
 embed_args = {


### PR DESCRIPTION
Allows summons to be added to an existing group or a specific group name defined with the `-group` argument when casting.

### What Alias/Snippet is this for?

### Summary
Here goes a short summary about what the PR is about.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
