### PR TITLE
add support for `-mc` to conc.alias

### DIFF
--- a/Collections/Initiative Utilities/conc.alias
+++ b/Collections/Initiative Utilities/conc.alias
@@ -18,6 +18,7 @@ adv = args.adv(boolwise=True)
 bladesong = args.last('bs') if self else None
 transmuter = args.last('ts') if self else None
 reroll = args.last('reroll', character().csettings.get('reroll') if self else None, type_=int)
+minimum_check = args.last('mc', None, int)
 
 rr = args.last('rr', 1, int)
 
@@ -27,14 +28,14 @@ if c and (target := c.get_combatant(target)):
   bladesong  = bladesong or target.get_effect("Bladesong")
   transmuter = transmuter or target.get_effect("Transmuter's Stone")
   sb         = ' + '.join([sb_ for eff in target.effects if (sb_ := eff.effect.get('sb', eff.effect.get('save_bonus')))])
-  rollString = f"{target.saves.get('constitution').d20(adv, reroll)}" +  \
+  rollString = f"{target.saves.get('constitution').d20(adv, reroll, minimum_check)}" +  \
               (f' + {b}' if b else '') +  \
               (f' + {sb}' if sb else '') + \
               (f' + {max(1, (target.stats.get_mod("int")))} [bladesong]' if bladesong else '') + \
               (f' + {(target.stats.prof_bonus)} [transmuter stone]' if transmuter else '')
 elif target == name:
   target = character()
-  rollString = f"{target.saves.get('constitution').d20(adv, reroll)}" +  \
+  rollString = f"{target.saves.get('constitution').d20(adv, reroll, minimum_check)}" +  \
               (f' + {b}' if b else '') + \
               (f' + {max(1, (target.stats.constitution-10)//2)} [bladesong]' if bladesong else '')
 else:

--- a/Collections/Initiative Utilities/conc.md
+++ b/Collections/Initiative Utilities/conc.md
@@ -7,6 +7,7 @@ __Valid Arguments__
 `-dc [dc]` - Sets the DC (Damage divided by 2, min 10).
 `adv`/`dis` - Rolls at advantage/disadantage. The alias checks for the 'War Caster' feat in a `feats` cvar, and for "Eldritch Mind" invocations in a `invocations` cvar (created manually, or set by the `!manage` alias).
 `-b [conditional bonus]` - Adds (or subtracts) a bonus to the saves (accepts dice).
+`-mc [minimum diceroll]` - Allows you to set a minimum roll on the save for features like Stars Druid: Dragon
 `bs` - Adds your Intelligence modifier for when Bladesong is active. The alias also checks for any active effects in init that grant save bonuses.
 `ts` - Adds your Proficiency bonus for when you're holding a Transmuter's stone that grants proficiency in Constitution Saves. The alias also checks for an effect called "Tranmuter's Stone" to apply the bonus. 
 `-reroll [#]` - Sets a reroll amount for the save.


### PR DESCRIPTION
Start Druid Starry Form Dragon. A constellation of a wise dragon appears on you. When you make an Intelligence or a Wisdom check or a Constitution saving throw to maintain concentration on a spell, you can treat a roll of 9 or lower on the d20 as a 10.

### What Alias/Snippet is this for?

### Summary
adding `-mc` support for `!conc`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
