### PR TITLE
More options on how recovering spell slots on short rest are handled

### DIFF
--- a/Collections/Croebh's Class Info/sr.alias
+++ b/Collections/Croebh's Class Info/sr.alias
@@ -53,6 +53,8 @@ hitDice = [f"d{x}" for x in range(20,0,-1)]
 
 Bardness = int(get('BardLevel',1))-1
 Warlockness = int(get('WarlockLevel',0))
+ignorePactSlots = int(get('ignorePactSlots',0))
+srslots = 'srslots' in character().csettings and character().csettings['srslots']
 yourRace = get("race",ch.race)
 Verdan = "ro<3" if yourRace.lower()=='verdan' else ""
 spentDice = []
@@ -125,7 +127,17 @@ if countersToResetO:
     counterFields[counterField] += counterText
   counterFields = [field.strip(', ') for field in counterFields if field]
   outText += ' -f "Reset Counters|'+'" -f "Continued|'.join(counterFields)+'"'
-if Warlockness:
+if srslots:
+  if sum([sb.get_max_slots(slotLevel) for slotLevel in range(1,10)]):
+   spellSlotText = ''
+   for slotLevel in range(1,10):
+    if sb.get_max_slots(slotLevel):
+     if delta := sb.get_max_slots(slotLevel)-sb.get_slots(slotLevel):
+      delta = f' ({delta:+})'
+     sb.set_slots(slotLevel,sb.get_max_slots(slotLevel))
+     spellSlotText += character().spellbook.slots_str(slotLevel)+(delta if delta else '')+n
+   outText += ', Spell Slots' if compact else f' -f "Spell Slots|{spellSlotText}|inline"'
+elif not ignorePactSlots and Warlockness:
   W = int(WarlockLevel)
   slotLevel = min(ceil(W/2),5)
   totalSlots = sb.get_max_slots(slotLevel)
@@ -136,6 +148,7 @@ if Warlockness:
   delta = min(sb.get_max_slots(slotLevel)-sb.get_slots(slotLevel)-int(get('ssSpent',0)),pactSlots)
   sb.set_slots(slotLevel,min(delta+sb.get_slots(slotLevel),sb.get_max_slots(slotLevel)))
   outText += f' -f "Spell Slots|{sb.slots_str(slotLevel)}{f" ({delta:+})" if delta else ""}"'
+
 hitDieText = ''
 for hitdie in ownedHitDice:
   delta = 0

--- a/Collections/Croebh's Class Info/sr.md
+++ b/Collections/Croebh's Class Info/sr.md
@@ -15,4 +15,4 @@ You can also just do `!sr X` to use X Hit Dice, starting with the largest availa
 
 **Verdan: Black Blood Healing:** If your race is set as Verdan, `!sr` will automatically reroll any 1s or 2s you roll on a Hit Die.
 
-`!sr` will try to automatically detect if you're a Warlock and recover pact slots appropriately. You can override this with `!cvar ignorePactSlots 1` to always disable recovering spell slots on short rest, or use `!csettings` -> Gameplay Settings -> Toggle Short Rest Slots to always recover *all* slots on short rest.
+**Warlock: Pact Slots:** `!sr` will try to automatically detect if you're a Warlock and recover pact slots appropriately. You can override this with `!cvar ignorePactSlots 1` to always disable recovering spell slots on short rest, or use `!csettings` -> Gameplay Settings -> Toggle Short Rest Slots to always recover *all* slots on short rest.

--- a/Collections/Croebh's Class Info/sr.md
+++ b/Collections/Croebh's Class Info/sr.md
@@ -14,3 +14,5 @@ You can also just do `!sr X` to use X Hit Dice, starting with the largest availa
 **Periapt of Wound Closure:** If you have a Periapt of Wound Closure, create a cvar named `attunedItems` and put `Periapt of Wound Closure` in it. You can also use the `periapt` or `closure` argument with the alias to apply the effect. 
 
 **Verdan: Black Blood Healing:** If your race is set as Verdan, `!sr` will automatically reroll any 1s or 2s you roll on a Hit Die.
+
+`!sr` will try to automatically detect if you're a Warlock and recover pact slots appropriately. You can override this with `!cvar ignorePactSlots 1` to always disable recovering spell slots on short rest, or use `!csettings` -> Gameplay Settings -> Toggle Short Rest Slots to always recover *all* slots on short rest.


### PR DESCRIPTION
### What Alias/Snippet is this for?

### Summary
1) add a check for `ignorePactSlots` cvar/uvar and don't try to account for pact slots if set

2) Recover all spell slots if character setting "Reset All Spell Slots on Short Rest"( `srslots`) is True.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
