### PR TITLE
Add support for noconc and -dur arguments

### DIFF
--- a/Collections/Croebhs Summon Alias/summon aberration.alias
+++ b/Collections/Croebhs Summon Alias/summon aberration.alias
@@ -50,9 +50,9 @@ match summon_type:
     attacks = [{"name":"Claws","automation":[{"type":"target","target":"each","effects":[{"type":"attack","attackBonus":sab,"hit":[{"type":"damage","damage":f"1d10 + 3 + {spell_level} [slashing]"},{"type":"ieffect2","name":"Festering Wound","duration":1,"desc":"Cannot heal","effects":{"immunities":["heal"]},"tick_on_caster":True}],"miss":[]}]},{"type":"text","text":"*Melee Weapon Attack:* your spell attack modifier to hit, reach 5 ft., one target. *Hit:* 1d10 + 3 + the spell's level slashing damage. If the target is a creature, it can't regain hit points until the start of the aberration's next turn."}],"_v":2,"verb":None,"proper":True,"activation_type":None}]
     extra_effects = [{"name":"Regeneration","desc":"Regains 5 hit points at the start of its turn if it has at least 1 hit point","buttons":[{"label":"Regenerate","verb":"begins to regenerate","style":"3","automation":[{"type":"target","target":"self","effects":[{"type":"damage","damage":"{min(0, caster.hp)-5} [heal]"}]},{"type":"text","text":"The slaad regains 5 hit points at the start of its turn if it has at least 1 hit point."}]}]}]
     summon_name = "Slaad"
-  case "star" | "star spawn" | "starspawn" | "spawn":
+  case "star" | "Mind Flayer" | "Mindflayer" | "flayer":
     attacks = [{"name":"Psychic Slam","automation":[{"type":"target","target":"each","effects":[{"type":"attack","attackBonus":sab,"hit":[{"type":"damage","damage":f"1d8 + 3 + {spell_level} [psychic]"}],"miss":[]}]},{"type":"text","text":"*Melee Spell Attack:* your spell attack modifier to hit, reach 5 ft., one creature. *Hit:* 1d8 + 3 + the spell's level psychic damage."}],"_v":2,"verb":None,"proper":False,"activation_type":None},{"name":"Whispering Aura","automation":[{"type":"roll","dice":"2d6 [psychic]","name":"damage"},{"type":"target","target":"each","effects":[{"type":"save","stat":"wis","dc":sdc,"fail":[{"type":"damage","damage":"{damage}"}],"success":[]}],"meta":[]},{"type":"text","text":"At the start of each of the aberration's turns, each creature within 5 feet of the aberration must succeed on a Wisdom saving throw against your spell save DC or take 2d6 psychic damage, provided that the aberration isn't incapacitated."}],"_v":2,"verb":"exudes"}]
-    summon_name = "Star Spawn"
+    summon_name = "Mind Flayer"
   case _:
     return f"""embed -title "Woopsie!" -desc "You didn't select a type!\n\nChoose from Beholder, Slaad or Star Spawn." """
 
@@ -79,7 +79,9 @@ stat_block['group'] = group_name
 stat_block['note'] = f"Summoned by {name}\nMultiattack: {max(1, spell_level//2)}"
 
 c.me.set_group(group_name)
-c.me.add_effect(f"Summon {TYPE}", concentration=True, duration=600)
+useconc = "noconc" not in args
+usedur = int(args.get("dur",[600])[0])
+c.me.add_effect(f"Summon {TYPE}", concentration=useconc, duration=usedur)
 
 embed_args = {
   "title": f"{name} summoned a {summon_name} {TYPE}!",


### PR DESCRIPTION
Add support for noconc and -dur arguments for the GOOLock feature Also change name to mind flayer in line with the new spell

### What Alias/Snippet is this for?

### Summary
Here goes a short summary about what the PR is about.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
