### PR TITLE
Update summon aberration.alias for cube of summoning

### DIFF
--- a/Collections/Croebhs Summon Alias/summon aberration.alias
+++ b/Collections/Croebhs Summon Alias/summon aberration.alias
@@ -9,8 +9,8 @@ using(init_add="f48672c2-8f25-4170-ba39-d5f6ffd38bd3")
 args = argparse(["-type"] + &ARGS&)
 c = combat()
 ch = character()
-sab = ch.spellbook.sab
-sdc = ch.spellbook.dc
+sab = int(args.last('mod', ch.spellbook.sab ))
+sdc = int(args.last('dc', ch.spellbook.dc)) 
 true, false, null = True, False, None
 
 warlock = ch.levels.get('Warlock')


### PR DESCRIPTION
Support -dc and -mod args to allow them to be set when cast from magic item

### What Alias/Snippet is this for?
Support cube of summoning

### Summary
Support -dc and -mod args to allow them to be set when cast from magic item

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
