### PR TITLE
Typo Fixed on exportAttack.md

### DIFF
--- a/Collections/Aliasing Utilities/exportAttack.md
+++ b/Collections/Aliasing Utilities/exportAttack.md
@@ -4,4 +4,4 @@ Exports an attack's raw data.
 
 Always sets `!uvar exported_attack` in case the output is too long.
 
-Can automatically import the attack on your current character using the `import` argumetn
+Can automatically import the attack on your current character using the `import` argument


### PR DESCRIPTION
I fixed the typo. the last two letters of the "word" argumetn were swapped.

### What Alias/Snippet is this for?
!exportAttack
### Summary
Here goes a short summary about what the PR is about.
the last word has two letters swapped. This annoyed me.
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I properly commented my code where appropriate
